### PR TITLE
Feature/tweet from url

### DIFF
--- a/lib/xombot.rb
+++ b/lib/xombot.rb
@@ -38,7 +38,8 @@ module XOmBot
 
     def add_plugin plugin
       @plugins = {} if @plugins.nil?
-      @plugins[plugin.class.name] = plugin
+      plugin_name = plugin.class.name[/^XOmBot::Plugins::(.*)/, 1]
+      @plugins[plugin_name] = plugin
     end
 
     def start

--- a/lib/xombot/plugin.rb
+++ b/lib/xombot/plugin.rb
@@ -5,7 +5,19 @@ module XOmBot
     def initialize *args
       # Register the plugin with XOmBot
       XOmBot.add_plugin self
+
+      # When all plugins are loaded, call setup on each
+      if XOmBot.plugins.count == XOmBot::Plugins.constants.count
+        XOmBot.plugins.each do |k, v|
+          v.setup
+        end
+      end
+
       super *args
+    end
+
+    # Called after all plugins have been loaded and initialized
+    def setup
     end
 
     module ModuleSet

--- a/lib/xombot/plugins/tweet.rb
+++ b/lib/xombot/plugins/tweet.rb
@@ -7,12 +7,26 @@ class Tweet < XOmBot::Plugin
   help "Displays the latest tweet by the given user"
   usage "tweet noob -- displays the last tweet by noob"
 
+  def setup
+    url_plugin = XOmBot.plugins["URLAnnounce"]
+    if url_plugin
+      url_plugin.match_domain("twitter.com") do |m, url|
+        tweet_by_url m, url
+      end
+    end
+  end
+
   def tweet_by_id(m, id)
     status = Twitter.status(id)
     m.reply "@#{status.user.screen_name}: #{HTMLEntities.new.decode status.text}"
   end
 
   def tweet_by_username(m, username)
-   m.reply "@#{username}: #{HTMLEntities.new.decode Twitter.user_timeline(username).first.text}" 
+    m.reply "@#{username}: #{HTMLEntities.new.decode Twitter.user_timeline(username).first.text}" 
+  end
+
+  def tweet_by_url(m, url)
+    id = url[/^https?:\/\/.*\/status\/(\d+)/,1]
+    tweet_by_id m, id
   end
 end

--- a/lib/xombot/plugins/url_announce.rb
+++ b/lib/xombot/plugins/url_announce.rb
@@ -2,7 +2,7 @@ class URLAnnounce < XOmBot::Plugin
   listen_to :channel
 
   def listen(m)
-    ignore_plugin = XOmBot.plugins["XOmBot::Plugins::Ignore"]
+    ignore_plugin = XOmBot.plugins["Ignore"]
     return if ignore_plugin and ignore_plugin.ignored.include? m.user.nick
 
     m.message.scan /https?:\/\/[\S]+/ do |url|

--- a/lib/xombot/plugins/url_announce.rb
+++ b/lib/xombot/plugins/url_announce.rb
@@ -6,10 +6,34 @@ class URLAnnounce < XOmBot::Plugin
     return if ignore_plugin and ignore_plugin.ignored.include? m.user.nick
 
     m.message.scan /https?:\/\/[\S]+/ do |url|
+      dispatch m, url
+    end
+  end
+
+  def dispatch(m, url)
+    domain = url[/https?:\/\/(?:[^.]+\.)?([^.]+\.[^\/]+)(?:\/|$)/, 1]
+
+    @callback = @callback || {}
+    if @callback[domain]
+      @callback[domain].call m, url
+    else
+      default_announce m, url
+    end
+  end
+
+  def match_domain(domain, &block)
+    @callback = @callback || {}
+    @callback[domain] = block
+  end
+
+  def default_announce(m, url)
+    begin
       page = Mechanize.new.get url
+
       if page.is_a? Mechanize::Page
         m.reply "Title: #{page.title.gsub(/\t|\r|\n/, " ").strip}"
       end
+    rescue
     end
   end
 end


### PR DESCRIPTION
These commits add functionality to URLAnnounce to override basic url announces.

I had to add a setup method for XOmBot::Plugin so that plugins can interact with others if they exist, which involved some cleanup of the plugin lookup.

I have added functionality to Tweet plugin so that it will better form tweet announcements when it sees such a url. That should prove the merit of the enhancements to URLAnnounce. Who knows what other uses we can find. :)
